### PR TITLE
Fixes import path for gdal.

### DIFF
--- a/ccb/read.py
+++ b/ccb/read.py
@@ -3,7 +3,7 @@
 import os as _os
 import pickle as _pickle
 
-import gdal as _gdal
+from osgeo import gdal as _gdal
 
 _gdal.UseExceptions()
 


### PR DESCRIPTION
The requirements in the packages specify the latest version of gdal.  With the latest version (now v3.5.0) the import path is now `from osgeo import gdal`. 